### PR TITLE
Add mobile responsive layout

### DIFF
--- a/lib/pages/landing_page_first_level.dart
+++ b/lib/pages/landing_page_first_level.dart
@@ -6,17 +6,19 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart'
 import 'package:omeeoweb/widgets/colors.dart';
 import 'package:omeeoweb/widgets/cutsom_widgets.dart'
     show CustomText, FeatureCard, RegularButton;
+import '../responsive.dart';
 
 class LandingPageFirstLevel extends StatelessWidget {
   const LandingPageFirstLevel({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final isMobile = Responsive.isMobile(context);
     return Stack(
       children: [
         Container(
           width: double.infinity,
-          height: 1000,
+          height: isMobile ? 700 : 1000,
           decoration: BoxDecoration(
             image: DecorationImage(
               image: AssetImage('assets/images/HowOftenWashCar_Header.jpg'),
@@ -30,7 +32,7 @@ class LandingPageFirstLevel extends StatelessWidget {
           child: BackdropFilter(
             filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5), // blur intensity
             child: Container(
-              height: 1007, // optional tint
+              height: isMobile ? 707 : 1007, // optional tint
             ),
           ),
         ),
@@ -38,7 +40,7 @@ class LandingPageFirstLevel extends StatelessWidget {
         // White overlay with opacity
         Container(
           width: double.infinity,
-          height: 1007,
+          height: isMobile ? 707 : 1007,
           color: const Color.fromARGB(
             212,
             246,
@@ -64,7 +66,7 @@ class LandingPageFirstLevel extends StatelessWidget {
               // Subtitle
               CustomText(
                 text: 'Premium Mobile Car Care',
-                textSize: 80,
+                textSize: isMobile ? 40 : 80,
                 textColor: AppColors.primaryPurple,
                 textWeight: FontWeight.w800,
               ),
@@ -76,14 +78,14 @@ class LandingPageFirstLevel extends StatelessWidget {
                 text:
                     'Professional mobile car wash and detailing services. We bring the car',
                 textAlign: TextAlign.center,
-                textSize: 25,
+                textSize: isMobile ? 16 : 25,
                 textColor: AppColors.textSecondary,
               ),
               CustomText(
                 text:
                     'Wash to your location with eco-friendly products and premium care.',
                 textAlign: TextAlign.center,
-                textSize: 25,
+                textSize: isMobile ? 16 : 25,
                 textColor: AppColors.textSecondary,
               ),
 
@@ -96,21 +98,23 @@ class LandingPageFirstLevel extends StatelessWidget {
                   RegularButton(
                     textWidget: CustomText(
                       text: 'Book Now',
-                      textSize: 20,
+                      textSize: isMobile ? 16 : 20,
                       textWeight: FontWeight.w600,
                       textColor: AppColors.background,
                     ),
                     onPressed: () {},
                     backgroundColor: AppColors.primaryPurple,
                     border: Border.all(color: AppColors.primaryPurple),
-                    padding: EdgeInsets.symmetric(vertical: 15, horizontal: 40),
+                    padding: EdgeInsets.symmetric(
+                        vertical: isMobile ? 12 : 15,
+                        horizontal: isMobile ? 20 : 40),
                     borderRadius: 10,
                   ),
                   SizedBox(width: 20),
                   RegularButton(
                     textWidget: CustomText(
                       text: 'View Services',
-                      textSize: 20,
+                      textSize: isMobile ? 16 : 20,
                       textWeight: FontWeight.w600,
                       textColor: AppColors.primaryPurple,
                     ),
@@ -118,7 +122,9 @@ class LandingPageFirstLevel extends StatelessWidget {
                     backgroundColor: Colors.white,
 
                     border: Border.all(color: AppColors.primaryPurple),
-                    padding: EdgeInsets.symmetric(vertical: 15, horizontal: 30),
+                    padding: EdgeInsets.symmetric(
+                        vertical: isMobile ? 12 : 15,
+                        horizontal: isMobile ? 20 : 30),
                     borderRadius: 10,
                   ),
                 ],
@@ -138,17 +144,17 @@ class LandingPageFirstLevel extends StatelessWidget {
                       size: 30,
                       color: Colors.black,
                     ),
-                    title: CustomText(
-                      text: 'Mobile Service',
-                      textColor: AppColors.black,
-                      textSize: 30,
-                      textWeight: FontWeight.bold,
-                    ),
-                    subtitle: CustomText(
-                      text: 'We come to your home or office',
-                      textColor: AppColors.textSecondary,
-                      textAlign: TextAlign.center,
-                      textSize: 20,
+                  title: CustomText(
+                    text: 'Mobile Service',
+                    textColor: AppColors.black,
+                    textSize: isMobile ? 24 : 30,
+                    textWeight: FontWeight.bold,
+                  ),
+                  subtitle: CustomText(
+                    text: 'We come to your home or office',
+                    textColor: AppColors.textSecondary,
+                    textAlign: TextAlign.center,
+                    textSize: isMobile ? 16 : 20,
                     ),
                     iconColor: AppColors.primaryPurple,
                   ),
@@ -158,17 +164,17 @@ class LandingPageFirstLevel extends StatelessWidget {
                       size: 30,
                       color: Colors.black,
                     ),
-                    title: CustomText(
-                      text: 'Eco-Friendly',
-                      textColor: AppColors.black,
-                      textSize: 30,
-                      textWeight: FontWeight.bold,
-                    ),
-                    subtitle: CustomText(
-                      text: 'Biodegradable products & water conservation',
-                      textAlign: TextAlign.center,
-                      textColor: AppColors.textSecondary,
-                      textSize: 20,
+                  title: CustomText(
+                    text: 'Eco-Friendly',
+                    textColor: AppColors.black,
+                    textSize: isMobile ? 24 : 30,
+                    textWeight: FontWeight.bold,
+                  ),
+                  subtitle: CustomText(
+                    text: 'Biodegradable products & water conservation',
+                    textAlign: TextAlign.center,
+                    textColor: AppColors.textSecondary,
+                    textSize: isMobile ? 16 : 20,
                     ),
                     iconColor: AppColors.primaryPurple,
                   ),
@@ -178,17 +184,17 @@ class LandingPageFirstLevel extends StatelessWidget {
                       size: 30,
                       color: Colors.black,
                     ),
-                    title: CustomText(
-                      text: 'Professional',
-                      textColor: AppColors.black,
-                      textSize: 30,
-                      textWeight: FontWeight.bold,
-                    ),
-                    subtitle: CustomText(
-                      text: 'Trained technicians & premium equipment',
-                      textAlign: TextAlign.center,
-                      textColor: AppColors.textSecondary,
-                      textSize: 20,
+                  title: CustomText(
+                    text: 'Professional',
+                    textColor: AppColors.black,
+                    textSize: isMobile ? 24 : 30,
+                    textWeight: FontWeight.bold,
+                  ),
+                  subtitle: CustomText(
+                    text: 'Trained technicians & premium equipment',
+                    textAlign: TextAlign.center,
+                    textColor: AppColors.textSecondary,
+                    textSize: isMobile ? 16 : 20,
                     ),
                     iconColor: AppColors.primaryPurple,
                   ),

--- a/lib/pages/landing_page_fith_level.dart
+++ b/lib/pages/landing_page_fith_level.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:omeeoweb/widgets/colors.dart';
 import 'package:omeeoweb/widgets/cutsom_widgets.dart';
+import '../responsive.dart';
 
 class LandingPageFithLevel extends StatelessWidget {
   const LandingPageFithLevel({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final isMobile = Responsive.isMobile(context);
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(color: AppColors.primaryPurple),
@@ -16,7 +18,7 @@ class LandingPageFithLevel extends StatelessWidget {
           CustomText(
             text: 'omeeo wash',
             textColor: AppColors.white,
-            textSize: 22,
+            textSize: isMobile ? 18 : 22,
             textWeight: FontWeight.w500,
           ),
           const SizedBox(height: 20),
@@ -24,14 +26,14 @@ class LandingPageFithLevel extends StatelessWidget {
             text:
                 'Professional mobile car wash and detailing services delivered to your location',
             textColor: const Color.fromARGB(150, 255, 255, 255),
-            textSize: 21,
+            textSize: isMobile ? 16 : 21,
             textWeight: FontWeight.w500,
           ),
           const SizedBox(height: 20),
           CustomText(
             text: '© 2024 omeeo wash. All rights reserved.',
             textColor: const Color.fromARGB(80, 255, 255, 255),
-            textSize: 20,
+            textSize: isMobile ? 14 : 20,
             textWeight: FontWeight.w500,
           ),
           const SizedBox(height: 40),

--- a/lib/pages/landing_page_fourth_level.dart
+++ b/lib/pages/landing_page_fourth_level.dart
@@ -4,12 +4,14 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:omeeoweb/widgets/colors.dart';
 import 'package:omeeoweb/widgets/cutsom_widgets.dart';
+import '../responsive.dart';
 
 class LandingPageFourthLevel extends StatelessWidget {
   const LandingPageFourthLevel({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final isMobile = Responsive.isMobile(context);
     return Container(
       color: AppColors.accentPurple,
       child: Column(
@@ -18,7 +20,7 @@ class LandingPageFourthLevel extends StatelessWidget {
           CustomText(
             text: 'Ready to Book with OMEEO wash?',
             textColor: AppColors.primaryPurple,
-            textSize: 65,
+            textSize: isMobile ? 40 : 65,
             textWeight: FontWeight.w800,
             textAlign: TextAlign.center,
           ),
@@ -27,7 +29,7 @@ class LandingPageFourthLevel extends StatelessWidget {
             text:
                 'Get in touch with us today to schedule your mobile car wash and detailing service',
             textColor: Colors.black54,
-            textSize: 25,
+            textSize: isMobile ? 16 : 25,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 20),
@@ -137,7 +139,7 @@ class ContactCard extends StatelessWidget {
               text: CustomText(
                 text: 'Call Now to Book',
                 textColor: AppColors.white,
-                textSize: 20,
+                textSize: isMobile ? 16 : 20,
                 textWeight: FontWeight.w600,
               ),
               onPressed: () {},
@@ -199,7 +201,7 @@ class _QuoteFormState extends State<QuoteForm> {
             CustomText(
               text: 'Request a Quote',
               textColor: AppColors.primaryPurple,
-              textSize: 30,
+              textSize: isMobile ? 24 : 30,
               textWeight: FontWeight.w600,
             ),
             const SizedBox(height: 20),
@@ -280,11 +282,11 @@ class _QuoteFormState extends State<QuoteForm> {
             !isLoading
                 ? HoverButton(
                   text: CustomText(
-                    text: 'Request Quote',
-                    textColor: AppColors.white,
-                    textSize: 20,
-                    textWeight: FontWeight.w600,
-                  ),
+                  text: 'Request Quote',
+                  textColor: AppColors.white,
+                  textSize: isMobile ? 16 : 20,
+                  textWeight: FontWeight.w600,
+                ),
                   onPressed: () async {
                     setState(() {
                       isLoading = true;
@@ -353,7 +355,7 @@ Future<int> sendQuoteEmail({
         content: Center(
           child: CustomText(
             text: 'Please complete the form.',
-            textSize: 20,
+            textSize: Responsive.isMobile(context) ? 16 : 20,
             textColor: AppColors.white,
           ),
         ),
@@ -393,7 +395,7 @@ Future<int> sendQuoteEmail({
         content: Center(
           child: CustomText(
             text: 'Message sent successfully!',
-            textSize: 20,
+            textSize: Responsive.isMobile(context) ? 16 : 20,
             textColor: AppColors.white,
           ),
         ),
@@ -410,7 +412,7 @@ Future<int> sendQuoteEmail({
         content: Center(
           child: CustomText(
             text: 'Failed to send message. Please try again.',
-            textSize: 20,
+            textSize: Responsive.isMobile(context) ? 16 : 20,
             textColor: AppColors.white,
           ),
         ),

--- a/lib/pages/landing_page_second_level.dart
+++ b/lib/pages/landing_page_second_level.dart
@@ -3,19 +3,21 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart'
     show FontAwesomeIcons;
 import 'package:omeeoweb/widgets/colors.dart';
 import 'package:omeeoweb/widgets/cutsom_widgets.dart';
+import '../responsive.dart';
 
 class LandingPageSecondLevel extends StatelessWidget {
   const LandingPageSecondLevel({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final isMobile = Responsive.isMobile(context);
     return Container(
       child: Column(
         children: [
           const SizedBox(height: 20),
           CustomText(
             text: 'Our Services',
-            textSize: 60,
+            textSize: isMobile ? 40 : 60,
             textColor: AppColors.primaryPurple,
             textWeight: FontWeight.w800,
           ),
@@ -23,14 +25,14 @@ class LandingPageSecondLevel extends StatelessWidget {
           CustomText(
             text:
                 'Choose from our comprehensive range of car care services, all performed at',
-            textSize: 25,
+            textSize: isMobile ? 16 : 25,
             textColor: AppColors.textSecondary,
             textWeight: FontWeight.w500,
           ),
 
           CustomText(
             text: 'your location',
-            textSize: 25,
+            textSize: isMobile ? 16 : 25,
             textColor: AppColors.textSecondary,
             textWeight: FontWeight.w500,
           ),
@@ -56,7 +58,7 @@ class LandingPageSecondLevel extends StatelessWidget {
                 ),
                 customText: CustomText(
                   text: 'Basic Wash',
-                  textSize: 30,
+                  textSize: isMobile ? 24 : 30,
                   textColor: AppColors.primaryPurple,
                   textWeight: FontWeight.w700,
                 ),
@@ -80,7 +82,7 @@ class LandingPageSecondLevel extends StatelessWidget {
                 ),
                 customText: CustomText(
                   text: 'Premium Detail',
-                  textSize: 30,
+                  textSize: isMobile ? 24 : 30,
                   textColor: AppColors.primaryPurple,
                   textWeight: FontWeight.w700,
                 ),
@@ -103,7 +105,7 @@ class LandingPageSecondLevel extends StatelessWidget {
                 ),
                 customText: CustomText(
                   text: 'Full Service',
-                  textSize: 30,
+                  textSize: isMobile ? 24 : 30,
                   textColor: AppColors.primaryPurple,
                   textWeight: FontWeight.w700,
                 ),
@@ -125,13 +127,13 @@ class LandingPageSecondLevel extends StatelessWidget {
                 title: CustomText(
                   text: 'Water Conservation',
                   textColor: AppColors.black,
-                  textSize: 21,
+                  textSize: isMobile ? 18 : 21,
                   textWeight: FontWeight.bold,
                 ),
                 subTitle: CustomText(
                   text: 'Eco-friendly washing',
                   textColor: AppColors.textSecondary,
-                  textSize: 18,
+                  textSize: isMobile ? 14 : 18,
                   textWeight: FontWeight.normal,
                 ),
               ),
@@ -144,13 +146,13 @@ class LandingPageSecondLevel extends StatelessWidget {
                 title: CustomText(
                   text: 'Interior Protection',
                   textColor: AppColors.black,
-                  textSize: 21,
+                  textSize: isMobile ? 18 : 21,
                   textWeight: FontWeight.bold,
                 ),
                 subTitle: CustomText(
                   text: 'Advanced care methods',
                   textColor: AppColors.textSecondary,
-                  textSize: 18,
+                  textSize: isMobile ? 14 : 18,
                   textWeight: FontWeight.normal,
                 ),
               ),
@@ -163,13 +165,13 @@ class LandingPageSecondLevel extends StatelessWidget {
                 title: CustomText(
                   text: 'Quick Service',
                   textColor: AppColors.black,
-                  textSize: 21,
+                  textSize: isMobile ? 18 : 21,
                   textWeight: FontWeight.bold,
                 ),
                 subTitle: CustomText(
                   text: 'Efficient & thorough',
                   textColor: AppColors.textSecondary,
-                  textSize: 18,
+                  textSize: isMobile ? 14 : 18,
                   textWeight: FontWeight.normal,
                 ),
               ),
@@ -182,13 +184,13 @@ class LandingPageSecondLevel extends StatelessWidget {
                 title: CustomText(
                   text: 'All Vehicle Types',
                   textColor: AppColors.black,
-                  textSize: 21,
+                  textSize: isMobile ? 18 : 21,
                   textWeight: FontWeight.bold,
                 ),
                 subTitle: CustomText(
                   text: 'Cars, trucks, SUVs',
                   textColor: AppColors.textSecondary,
-                  textSize: 16,
+                  textSize: isMobile ? 14 : 16,
                   textWeight: FontWeight.normal,
                 ),
               ),

--- a/lib/pages/landing_page_third_level.dart
+++ b/lib/pages/landing_page_third_level.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omeeoweb/widgets/colors.dart';
 import 'package:omeeoweb/widgets/cutsom_widgets.dart';
+import '../responsive.dart';
 
 class LandingPageThirdLevel extends StatelessWidget {
   const LandingPageThirdLevel({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final isMobile = Responsive.isMobile(context);
     return Container(
       color: const Color.fromARGB(6, 62, 0, 161),
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 50),
@@ -21,7 +23,7 @@ class LandingPageThirdLevel extends StatelessWidget {
                 CustomText(
                   text: 'Why Choose OMEEO wash?',
                   textColor: AppColors.primaryPurple,
-                  textSize: 50,
+                  textSize: isMobile ? 32 : 50,
                   textWeight: FontWeight.w800,
                 ),
                 const SizedBox(height: 10),
@@ -29,7 +31,7 @@ class LandingPageThirdLevel extends StatelessWidget {
                   text:
                       'We revolutionize car care by bringing professional detailing services directly to your doorstep. No more waiting in line or driving to car washes - we handle everything while you focus on what matters most.',
                   textColor: AppColors.textSecondary,
-                  textSize: 21,
+                  textSize: isMobile ? 16 : 21,
                   textWeight: FontWeight.w500,
                 ),
                 const SizedBox(height: 30),
@@ -94,13 +96,13 @@ class LandingPageThirdLevel extends StatelessWidget {
                         CustomText(
                           text: '100+',
                           textColor: AppColors.primaryPurple,
-                          textSize: 35,
+                          textSize: isMobile ? 28 : 35,
                           textWeight: FontWeight.w700,
                         ),
                         CustomText(
                           text: 'Happy Customers',
                           textColor: AppColors.textSecondary,
-                          textSize: 18,
+                          textSize: isMobile ? 14 : 18,
                         ),
                       ],
                     ),
@@ -123,13 +125,13 @@ class LandingPageThirdLevel extends StatelessWidget {
                         CustomText(
                           text: '5+',
                           textColor: AppColors.white,
-                          textSize: 35,
+                          textSize: isMobile ? 28 : 35,
                           textWeight: FontWeight.w700,
                         ),
                         CustomText(
                           text: 'Years Experience',
                           textColor: AppColors.white,
-                          textSize: 18,
+                          textSize: isMobile ? 14 : 18,
                         ),
                       ],
                     ),
@@ -147,6 +149,7 @@ class LandingPageThirdLevel extends StatelessWidget {
     required String title,
     required String description,
   }) {
+    final isMobile = Responsive.isMobile(context);
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -167,13 +170,13 @@ class LandingPageThirdLevel extends StatelessWidget {
               CustomText(
                 text: title,
                 textColor: AppColors.primaryPurple,
-                textSize: 25,
+                textSize: isMobile ? 20 : 25,
                 textWeight: FontWeight.w600,
               ),
               CustomText(
                 text: description,
                 textColor: AppColors.textSecondary,
-                textSize: 18,
+                textSize: isMobile ? 14 : 18,
               ),
             ],
           ),

--- a/lib/responsive.dart
+++ b/lib/responsive.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Helper class for responsive layout breakpoints.
+class Responsive {
+  const Responsive._();
+
+  /// Returns true when the screen width is less than 600px.
+  static bool isMobile(BuildContext context) {
+    return MediaQuery.of(context).size.width < 600;
+  }
+}

--- a/lib/widgets/cutsom_widgets.dart
+++ b/lib/widgets/cutsom_widgets.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart'
     show FontAwesomeIcons;
 import 'package:omeeoweb/widgets/colors.dart';
+import '../responsive.dart';
 
 class CustomText extends StatelessWidget {
   final String text;
@@ -117,6 +118,7 @@ class _FeatureCardState extends State<FeatureCard> {
 
   @override
   Widget build(BuildContext context) {
+    final cardWidth = Responsive.isMobile(context) ? double.infinity : 290.0;
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
@@ -125,7 +127,7 @@ class _FeatureCardState extends State<FeatureCard> {
         duration: const Duration(milliseconds: 200),
         child: Container(
           height: 220,
-          width: 290,
+          width: cardWidth,
           padding: const EdgeInsets.all(16),
           margin: const EdgeInsets.symmetric(horizontal: 15, vertical: 16),
           decoration: BoxDecoration(
@@ -183,6 +185,7 @@ class _ServiceCardState extends State<ServiceCard> {
 
   @override
   Widget build(BuildContext context) {
+    final cardWidth = Responsive.isMobile(context) ? double.infinity : 350.0;
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
@@ -190,7 +193,7 @@ class _ServiceCardState extends State<ServiceCard> {
         scale: _isHovered ? 1.05 : 1.0,
         duration: const Duration(milliseconds: 200),
         child: Container(
-          width: 350,
+          width: cardWidth,
           padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 20),
           margin: const EdgeInsets.symmetric(horizontal: 15, vertical: 16),
           decoration: BoxDecoration(
@@ -284,8 +287,9 @@ class PrincipleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final horizontal = Responsive.isMobile(context) ? 20.0 : 50.0;
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 50),
+      padding: EdgeInsets.symmetric(horizontal: horizontal),
       child: Column(
         children: [
           const SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- introduce a `Responsive` helper class
- adjust feature and service cards for mobile width
- scale text sizes and padding across landing pages
- tweak contact form and footer for small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68518c17caf88321a460d3fd2c481e2a